### PR TITLE
Switch to RunnableSequence

### DIFF
--- a/ai_scout_lite/cases.py
+++ b/ai_scout_lite/cases.py
@@ -8,7 +8,6 @@ from typing import List, Optional
 
 import pandas as pd
 from duckduckgo_search import DDGS
-from langchain.chains import LLMChain
 from langchain_openai import OpenAI
 #from langchain.llms import OpenAI
 from langchain.prompts import PromptTemplate
@@ -59,8 +58,8 @@ def analyze_url(url: str, topic_id: int, org: str) -> Optional[AICase]:
 
     llm = OpenAI(temperature=0)
     prompt = PromptTemplate(template=PROMPT_CASE_FILTER, input_variables=["text"])
-    chain = LLMChain(prompt=prompt, llm=llm)
-    result = chain.run(text=text[:4000])  # ответ от LLM
+    chain = prompt | llm
+    result = chain.invoke({"text": text[:4000]})  # ответ от LLM
 
     try:
         import json

--- a/ai_scout_lite/discover.py
+++ b/ai_scout_lite/discover.py
@@ -11,7 +11,6 @@ from duckduckgo_search import DDGS
 #from langchain.llms import OpenAI
 from langchain_openai import OpenAI
 from langchain.prompts import PromptTemplate
-from langchain.chains import LLMChain
 import trafilatura
 
 # Включаем кэширование HTTP-запросов
@@ -71,9 +70,9 @@ def summarize_org(texts: List[str]) -> OrgInsights:
     "7M_As3Gy0vyDG4RGw4rwYI-EsqZ0Sg0X7nxtHqWgerqyB7K68A"
     )
     prompt = PromptTemplate(template=PROMPT_SUMMARY, input_variables=["text"])
-    chain = LLMChain(prompt=prompt, llm=llm)
+    chain = prompt | llm
     joined = "\n".join(texts)[:4000]  # объединяем тексты и ограничиваем длину
-    result = chain.run(text=joined)  # запрос к LLM с текстом
+    result = chain.invoke({"text": joined})  # запрос к LLM с текстом
     try:
         import json
 

--- a/ai_scout_lite/pilots.py
+++ b/ai_scout_lite/pilots.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import List
 
-from langchain.chains import LLMChain
 from langchain_openai import OpenAI
 #from langchain.llms import OpenAI
 from langchain.prompts import PromptTemplate
@@ -37,8 +36,8 @@ def generate_pilot(org: str, task: str, case_task: str, partner: str) -> PilotPr
         template=PROMPT_PILOT_GEN,
         input_variables=["org", "task", "case_task", "partner"],
     )
-    chain = LLMChain(prompt=prompt, llm=llm)
-    text = chain.run(org=org, task=task, case_task=case_task, partner=partner)
+    chain = prompt | llm
+    text = chain.invoke({"org": org, "task": task, "case_task": case_task, "partner": partner})
     lines = text.split("\n", 1)  # отделяем заголовок от тела
     title = lines[0].strip() if lines else "Пилот"
     body = lines[1].strip() if len(lines) > 1 else ""

--- a/ai_scout_lite/validator.py
+++ b/ai_scout_lite/validator.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from langchain.chains import LLMChain
 #from langchain.llms import OpenAI
 from langchain_openai import OpenAI
 from langchain.prompts import PromptTemplate
@@ -30,8 +29,8 @@ def validate_pilot(pilot_text: str) -> ValidationResult:
     """Запрос к LLM для оценки пилотного проекта."""
     llm = OpenAI(temperature=0)
     prompt = PromptTemplate(template=PROMPT_VALIDATION, input_variables=["pilot"])
-    chain = LLMChain(prompt=prompt, llm=llm)
-    result = chain.run(pilot=pilot_text)  # ответ LLM
+    chain = prompt | llm
+    result = chain.invoke({"pilot": pilot_text})  # ответ LLM
     try:
         import json
 


### PR DESCRIPTION
## Summary
- update discover, cases, pilots and validator modules to use `prompt | llm`
- call `invoke` instead of `run`
- drop `LLMChain` imports

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6851f5fb1624832cb6045f730d388f59